### PR TITLE
feat: add global request fail event

### DIFF
--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -9,6 +9,9 @@ export class Request {
 
     this.setRequestHeader('X-Requested-With', 'XMLHttpRequest')
     this.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded')
+    this.fail(function (xhr: XMLHttpRequest) {
+      document.dispatchEvent(new CustomEvent('pollcast:request-error', { detail: xhr }))
+    })
   }
 
   success (cb: Function): Request {

--- a/test/http/request.test.ts
+++ b/test/http/request.test.ts
@@ -57,11 +57,25 @@ describe('failed requests', () => {
       .fail(cb)
       .send()
 
-    const [[, load]] = addEventListener.mock.calls
-    load()
+    expect(addEventListener.mock.calls.length).toBe(2)
+    addEventListener.mock.calls[1][1]()
 
     expect(cb).toBeCalledTimes(1)
     expect(cb).toHaveBeenCalledWith(xhr)
+  })
+
+  it('dispatches event on request failure', (done) => {
+    document.addEventListener('pollcast:request-error', function (e) {
+      // @ts-ignore
+      expect(e.detail).toBe(xhr)
+      done()
+    })
+
+    const request = new Request('GET', 'some/url')
+    request.send()
+
+    expect(addEventListener.mock.calls.length).toBe(1)
+    addEventListener.mock.calls[0][1]()
   })
 })
 
@@ -119,8 +133,8 @@ describe('successful requests', () => {
       .success(cb)
       .send()
 
-    const [[, load]] = addEventListener.mock.calls
-    load()
+    expect(addEventListener.mock.calls.length).toBe(2)
+    addEventListener.mock.calls[1][1]()
 
     expect(cb).toBeCalledTimes(1)
     expect(cb).toHaveBeenCalledWith(xhr)
@@ -134,8 +148,8 @@ describe('successful requests', () => {
       })
       .send()
 
-    const [[, load]] = addEventListener.mock.calls
-    load()
+    expect(addEventListener.mock.calls.length).toBe(2)
+    addEventListener.mock.calls[1][1]()
   })
 
   it('can abort request', () => {

--- a/test/http/request.test.ts
+++ b/test/http/request.test.ts
@@ -44,8 +44,8 @@ describe('failed requests', () => {
       .success(cb)
       .send()
 
-    const [[, load]] = addEventListener.mock.calls
-    load()
+    expect(addEventListener.mock.calls.length).toBe(2)
+    addEventListener.mock.calls[1][1]()
 
     expect(cb).toBeCalledTimes(0)
   })


### PR DESCRIPTION
Usage:
```js
document.addEventListener("pollcast:request-error", function(e) {
  console.log(e.detail); // Prints XHR request object
  // Echo.disconnect();
});
```