### PR TITLE
fix: unset socket id after disconnection

### DIFF
--- a/src/http/socket.ts
+++ b/src/http/socket.ts
@@ -143,6 +143,7 @@ export class Socket {
    * Disconnect the client from the server.
    */
   disconnect (): void {
+    this.id = ''
     if (this.request) {
       this.request.abort()
     }
@@ -175,8 +176,11 @@ export class Socket {
     }
 
     if (!WindowVisibility.isActive() || isEmptyObject(channels)) {
-      /* istanbul ignore next */
-      self.timer = setTimeout(() => self.poll(), this.options.polling)
+      /* istanbul ignore else */
+      if (this.id !== '') {
+        /* istanbul ignore next */
+        self.timer = setTimeout(() => self.poll(), this.options.polling)
+      }
       return
     }
 
@@ -192,8 +196,11 @@ export class Socket {
         }
       })
       .always(() => {
-        /* istanbul ignore next */
-        self.timer = setTimeout(() => self.poll(), self.options.polling)
+        // only if the socket is active
+        if (this.id !== '') {
+          /* istanbul ignore next */
+          self.timer = setTimeout(() => self.poll(), self.options.polling)
+        }
       })
       .send({
         time: this.universalTime.getTime(),

--- a/test/http/socket.test.ts
+++ b/test/http/socket.test.ts
@@ -641,4 +641,59 @@ describe('disconnect', () => {
 
     expect(clearTimeout).toHaveBeenCalledTimes(1)
   })
+
+  it('unsets socket id', () => {
+    const socket = new Socket({}, 'foo')
+    socket.disconnect()
+    expect(socket.id).toBe('')
+  })
+
+  it('stops polling in always callback after disconnect', () => {
+    const mockSend = jest.fn()
+    const timeoutSpy = jest.spyOn(window, 'setTimeout')
+
+    const token = 'foo'; const route = '/connect'
+    const socket = new Socket({ routes: { connect: route } }, token)
+
+    request
+        // connect implementation
+        .mockImplementationOnce(() : any => {
+          return {
+            abort: jest.fn(),
+            success: jest.fn(function (this: Request, cb) {
+              const xhr = { responseText: '{"status": "success"}' }
+              cb(xhr)
+
+              return this
+            }),
+            send: jest.fn()
+          }
+        })
+        // poll implementation
+        .mockImplementationOnce(() : any => {
+          return {
+            abort: jest.fn(),
+            success: jest.fn().mockReturnThis(),
+            fail: jest.fn().mockReturnThis(),
+            always: jest.fn(function (this: Request, cb) {
+              socket.disconnect()
+              cb()
+
+              return this
+            }),
+            send: mockSend
+          }
+        })
+
+    WindowVisibility.setActive()
+    Object.defineProperty(socket, 'channels', {
+      value: { channel1: { new_message: [() => {}] } },
+      writable: true
+    })
+
+    socket.connect()
+
+    expect(mockSend).toBeCalledTimes(1)
+    expect(timeoutSpy).toBeCalledTimes(0)
+  })
 })


### PR DESCRIPTION
Disconnecting from a socket doesn't stop pollcast from looping. This MR resolves that.