### PR TITLE
chore: update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "repository": {
     "url": "https://github.com/supportpal/pollcast-js"
   },
-  "main": "dist/pollcast.js",
-  "browser": "dist/pollcast.js",
-  "module": "src/pollcast.js",
+  "main": "./dist/pollcast.js",
+  "exports": "./dist/pollcast.js",
+  "browser": "./dist/pollcast.js",
+  "module": "./src/pollcast.js",
   "scripts": {
     "build": "npx gulp build",
     "lint": "eslint src test --ext .js,.ts",


### PR DESCRIPTION
Fixes this error when trying to use the package with vite.
```
Internal server error: Failed to resolve entry for package "@supportpal/pollcast". The package may have incorrect main/module/exports specified in its package.json.
```