### PR TITLE
fix: use session storage for universal time

### DIFF
--- a/src/util/__tests__/session-storage.test.ts
+++ b/src/util/__tests__/session-storage.test.ts
@@ -1,0 +1,31 @@
+import { SessionStorage } from '../session-storage'
+
+describe('session storage', () => {
+  it('can get when no values are stored', () => {
+    const sessionStorage = new SessionStorage('foo')
+    expect(sessionStorage.get()).toEqual({})
+  })
+
+  it('store a value', () => {
+    const sessionStorage = new SessionStorage('foo')
+    sessionStorage.set('bar', 'bar')
+
+    expect(sessionStorage.get().bar).toEqual('bar')
+  })
+
+  it('returns empty object on json parse error', () => {
+    const key = 'foo'
+    sessionStorage.setItem(key, '{foo,}')
+
+    const storage = new SessionStorage(key)
+    expect(storage.get()).toEqual({})
+  })
+
+  it('returns empty object on unexpected serialized json value', () => {
+    const key = 'foo'
+    sessionStorage.setItem(key, '"foo"')
+
+    const storage = new SessionStorage(key)
+    expect(storage.get()).toEqual({})
+  })
+})

--- a/src/util/session-storage.ts
+++ b/src/util/session-storage.ts
@@ -1,0 +1,32 @@
+export class SessionStorage {
+  private readonly key
+
+  constructor (key : string) {
+    this.key = key
+  }
+
+  get () : any {
+    let data = sessionStorage.getItem(this.key)
+    if (data === null) {
+      return {}
+    }
+
+    try {
+      data = JSON.parse(data)
+      if (typeof data === 'object') {
+        return data
+      }
+
+      return {}
+    } catch (err) {
+      return {}
+    }
+  }
+
+  set (key : string, value : any) : void {
+    const data = this.get()
+    data[key] = value
+
+    sessionStorage.setItem(this.key, JSON.stringify(data))
+  };
+}

--- a/src/util/universal-time.ts
+++ b/src/util/universal-time.ts
@@ -4,10 +4,10 @@
  * Prevents one Window from being behind / ahead of another
  * and events being displayed multiple times.
  */
-import { LocalStorage } from './local-storage'
+import { SessionStorage } from './session-storage'
 
 export class UniversalTime {
-  private storage : LocalStorage = new LocalStorage('universal_time')
+  private storage : SessionStorage = new SessionStorage('universal_time')
 
   setTime (time : string) : void {
     this.storage.set('time', time)


### PR DESCRIPTION
This ensures you don't lose updates when you switch tab to another tab where pollcast is enabled and then back.